### PR TITLE
fix: cannot load token list on godwoken v0 mainnet

### DIFF
--- a/src/light-godwoken/LightGodwokenV1.ts
+++ b/src/light-godwoken/LightGodwokenV1.ts
@@ -128,7 +128,7 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
   getBuiltinSUDTList(): SUDT[] {
     const sudtList: SUDT[] = [];
     const sudtScriptConfig = this.provider.getConfig().layer1Config.SCRIPTS.sudt;
-    getTokenList(isMainnet).v1.forEach((token) => {
+    getTokenList().v1.forEach((token) => {
       const tokenL1Script: Script = {
         code_hash: sudtScriptConfig.code_hash,
         hash_type: sudtScriptConfig.hash_type as HashType,
@@ -147,7 +147,7 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
   getBuiltinErc20List(): ProxyERC20[] {
     const map: ProxyERC20[] = [];
     const sudtScriptConfig = this.provider.getConfig().layer1Config.SCRIPTS.sudt;
-    getTokenList(isMainnet).v1.forEach((token) => {
+    getTokenList().v1.forEach((token) => {
       const tokenL1Script: Script = {
         code_hash: sudtScriptConfig.code_hash,
         hash_type: sudtScriptConfig.hash_type as HashType,

--- a/src/light-godwoken/constants/godwokenTokensV0.ts
+++ b/src/light-godwoken/constants/godwokenTokensV0.ts
@@ -4,15 +4,6 @@ import { LightGodwokenTokenType } from "./configTypes";
 export const TOKEN_LIST_V0_MAINNET: LightGodwokenTokenType[] = [
   {
     id: 0,
-    symbol: "CKB",
-    name: "CKB",
-    decimals: 8,
-    tokenURI: "https://cryptologos.cc/logos/nervos-network-ckb-logo.svg?v=002",
-    address: "0x9D9599c41383D7009C2093319d576AA6F89A4449",
-    l1LockArgs: "0x0000000000000000000000000000000000000000000000000000000000000000",
-  },
-  {
-    id: 0,
     symbol: "dCKB",
     name: "dCKB",
     decimals: 8,

--- a/src/light-godwoken/constants/godwokenTokensV1.ts
+++ b/src/light-godwoken/constants/godwokenTokensV1.ts
@@ -4,15 +4,6 @@ import { LightGodwokenTokenType } from "./configTypes";
 export const TOKEN_LIST_V1_MAINNET: LightGodwokenTokenType[] = [
   {
     id: 0,
-    symbol: "pCKB",
-    name: "pCKB",
-    decimals: 18,
-    tokenURI: "https://cryptologos.cc/logos/nervos-network-ckb-logo.svg?v=002",
-    address: "0x7538C85caE4E4673253fFd2568c1F1b48A71558a",
-    l1LockArgs: "0x0000000000000000000000000000000000000000000000000000000000000000",
-  },
-  {
-    id: 0,
     symbol: "dCKB",
     name: "dCKB",
     decimals: 8,

--- a/src/light-godwoken/constants/lightGodwokenConfig.ts
+++ b/src/light-godwoken/constants/lightGodwokenConfig.ts
@@ -150,6 +150,8 @@ const v0ConfigLina: LightGodwokenConfig = {
     FINALITY_BLOCKS: 3600,
     BLOCK_PRODUCE_TIME: 45,
     MIN_CANCEL_DEPOSIT_TIME: 172800, // two days
+
+    MULTICALL_ADDRESS: "0x277FD6c744f7C16A997E5D626131eBd81d2D58Aa",
   },
 };
 

--- a/src/light-godwoken/constants/tokens.ts
+++ b/src/light-godwoken/constants/tokens.ts
@@ -1,6 +1,7 @@
 import { LightGodwokenTokenType } from "./configTypes";
 import { TOKEN_LIST_V0_MAINNET } from "./godwokenTokensV0";
 import { TOKEN_LIST_V1_MAINNET } from "./godwokenTokensV1";
+import { isMainnet } from "../env";
 
 export const CKB_SUDT_ID = 1; // This is default sudt id fro ckb on Godwoken
 
@@ -100,7 +101,7 @@ export const TOKEN_LIST_V1: LightGodwokenTokenType[] = [
   },
 ];
 
-export const getTokenList = (isMainnet = false) => {
+export const getTokenList = () => {
   if (isMainnet) {
     return {
       v0: TOKEN_LIST_V0_MAINNET,


### PR DESCRIPTION
This PR enhanced:

- the `0x0000000000000000000000000000000000000000` in unnecessary when deposit or withdrawal
- multicall2 for godwoken mainnet v0
- cannot fetch token list on godwoken v0 mainnet