### PR TITLE
feat: prompt user message if withdrawal fail

### DIFF
--- a/src/components/Withdrawal/RequestWithdrawalV1.tsx
+++ b/src/components/Withdrawal/RequestWithdrawalV1.tsx
@@ -77,19 +77,9 @@ const RequestWithdrawalV1: React.FC<{ addTxToHistory: (txHistory: BaseL1TxHistor
       setCKBInput("");
       setSudtValue("");
       setLoading(false);
-      // commented here, will reopen after godwoken 1.2 goes live
-      // addTxToHistory({
-      //   type: "withdrawal",
-      //   txHash,
-      //   capacity,
-      //   amount,
-      //   token: selectedSudt,
-      //   status: "l2Pending",
-      // });
     });
 
     eventEmitter.on("fail", (result: unknown) => {
-      console.log("fail triggerd:", result);
       setLoading(false);
       handleError(result, selectedSudt);
     });

--- a/src/components/Withdrawal/service.ts
+++ b/src/components/Withdrawal/service.ts
@@ -1,7 +1,13 @@
 import { BI } from "@ckb-lumos/bi";
 import { captureException } from "@sentry/react";
 import { notification } from "antd";
-import { NotEnoughCapacityError, NotEnoughSudtError, TransactionSignError } from "../../light-godwoken/constants/error";
+import {
+  NotEnoughCapacityError,
+  NotEnoughSudtError,
+  TransactionSignError,
+  V0WithdrawTokenNotEnoughError,
+  V1WithdrawTokenNotEnoughError,
+} from "../../light-godwoken/constants/error";
 import { L1MappedErc20 } from "../../types/type";
 import { getFullDisplayAmount } from "../../utils/formatTokenAmount";
 import { formatToThousands } from "../../utils/numberFormat";
@@ -38,8 +44,20 @@ export const handleError = (e: unknown, selectedSudt?: L1MappedErc20) => {
     });
     return;
   }
-  captureException(e);
+  if (e instanceof V1WithdrawTokenNotEnoughError) {
+    notification.error({
+      message: `Withdrawalable token not enough, token can be withdrawed after staying on layer 2 for at least challenge time`,
+    });
+    return;
+  }
+  if (e instanceof V0WithdrawTokenNotEnoughError) {
+    notification.error({
+      message: `Withdrawalable token not enough, token can be withdrawed after staying on layer 2 for at least challenge time`,
+    });
+    return;
+  }
 
+  captureException(e);
   notification.error({
     message: `Unknown Error, Please try again later`,
   });

--- a/src/light-godwoken/LightGodwokenV1.ts
+++ b/src/light-godwoken/LightGodwokenV1.ts
@@ -30,6 +30,7 @@ import {
   NotEnoughSudtError,
   SudtNotFoundError,
   TransactionSignError,
+  V1WithdrawTokenNotEnoughError,
 } from "./constants/error";
 import {
   getAdvancedSettings,
@@ -306,7 +307,7 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
       eventEmitter.emit("fail", new TransactionSignError(JSON.stringify(typedMsg), e.message));
     }
 
-    // construct WithdrawalRequestExx tra
+    // construct WithdrawalRequestExtra
     const withdrawalReq = {
       raw: rawWithdrawalRequest,
       signature: signedMessage,
@@ -319,17 +320,19 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
 
     // submit WithdrawalRequestExtra
     const serializedRequest = new toolkit.Reader(WithdrawalRequestExtraCodec.pack(withdrawalReqExtra)).serializeJson();
-    const txHash = await this.godwokenClient.submitWithdrawalRequest(serializedRequest);
-    debug("result:", txHash);
-    if (txHash !== null) {
-      const errorMessage = (txHash as any).message;
-      if (errorMessage !== undefined && errorMessage !== null) {
-        eventEmitter.emit("fail", new Layer2RpcError(txHash, errorMessage));
-      }
+    let txHash: string | null = null;
+    try {
+      txHash = await this.godwokenClient.submitWithdrawalRequest(serializedRequest);
+      debug("result:", txHash);
+    } catch (error) {
+      const rpcError = new V1WithdrawTokenNotEnoughError(JSON.stringify(error), "Send withdrawal failed!");
+      eventEmitter.emit("fail", rpcError);
     }
-    eventEmitter.emit("sent", txHash);
-    debug("withdrawal request result:", txHash, eventEmitter);
-    this.waitForWithdrawalToComplete(txHash, eventEmitter);
+    if (txHash) {
+      eventEmitter.emit("sent", txHash);
+      debug("withdrawal request result:", txHash, eventEmitter);
+      this.waitForWithdrawalToComplete(txHash, eventEmitter);
+    }
   }
 
   generateTypedMsg(rawWithdrawalRequest: RawWithdrawalRequestV1) {

--- a/src/light-godwoken/constants/error.ts
+++ b/src/light-godwoken/constants/error.ts
@@ -17,6 +17,9 @@ export class NotEnoughSudtError extends LightGodwokenError<{ expected: BI; actua
 export class Layer1RpcError extends LightGodwokenError<string> {}
 export class Layer2RpcError extends LightGodwokenError<string> {}
 
+export class V1WithdrawTokenNotEnoughError extends LightGodwokenError<string> {}
+export class V0WithdrawTokenNotEnoughError extends LightGodwokenError<string> {}
+
 export class EthAddressFormatError extends LightGodwokenError<{ address: string }> {}
 export class Layer2AccountIdNotFoundError extends LightGodwokenError<string> {}
 export class ERC20TokenNotFoundError extends LightGodwokenError<{ sudtScriptHash: HexString }> {}


### PR DESCRIPTION
motivation: User will get stuck if he/she deposits asset to layer 2 and then withdraw immediatlly, we should tell user why withdrawal fails.

The reason is tokens should stay on layer 2 for some time(will make it acurate in future PR) until it can be withdrawed.