### PR TITLE
feat: tips for withdrawal info will appear within 5 min

### DIFF
--- a/src/components/Withdrawal/ListV0.tsx
+++ b/src/components/Withdrawal/ListV0.tsx
@@ -7,6 +7,8 @@ import WithdrawalRequestCard from "./WithdrawalItemV0";
 import { Placeholder } from "../Placeholder";
 import { LinkList, Tab } from "../../style/common";
 import { LightGodwokenV0 } from "../../light-godwoken";
+import Tooltip from "antd/lib/tooltip";
+import QuestionCircleOutlined from "@ant-design/icons/lib/icons/QuestionCircleOutlined";
 
 const WithdrawalListDiv = styled.div`
   border-bottom-left-radius: 24px;
@@ -57,7 +59,10 @@ export const WithdrawalList: React.FC = () => {
     <WithdrawalListDiv>
       <LinkList>
         <Tab onClick={changeViewToPending} className={active === "pending" ? "active" : ""}>
-          Pending
+          <Tooltip title="After a successful withdrawal transaction is sent, it usually comes up in the pending list within five minutes.">
+            Pending
+            <QuestionCircleOutlined style={{ marginLeft: 8, color: "#000000", height: "21px", lineHeight: "21px" }} />
+          </Tooltip>
         </Tab>
         <Tab onClick={changeViewToCompleted} className={active === "completed" ? "active" : ""}>
           Completed

--- a/src/components/Withdrawal/ListV1.tsx
+++ b/src/components/Withdrawal/ListV1.tsx
@@ -7,6 +7,8 @@ import { Placeholder } from "../Placeholder";
 import { LinkList, Tab } from "../../style/common";
 import LightGodwokenV1 from "../../light-godwoken/LightGodwokenV1";
 import { L1TxHistoryInterface } from "../../hooks/useL1TxHistory";
+import Tooltip from "antd/lib/tooltip";
+import QuestionCircleOutlined from "@ant-design/icons/lib/icons/QuestionCircleOutlined";
 
 const WithdrawalListDiv = styled.div`
   border-bottom-left-radius: 24px;
@@ -71,7 +73,10 @@ export const WithdrawalList: React.FC<Props> = ({ txHistory: localTxHistory }) =
     <WithdrawalListDiv>
       <LinkList>
         <Tab onClick={changeViewToPending} className={active === "pending" ? "active" : ""}>
-          Pending
+          <Tooltip title="After a successful withdrawal transaction is sent, it usually comes up in the pending list within five minutes.">
+            Pending
+            <QuestionCircleOutlined style={{ marginLeft: 8, color: "#000000", height: "21px", lineHeight: "21px" }} />
+          </Tooltip>
         </Tab>
         <Tab onClick={changeViewToCompleted} className={active === "completed" ? "active" : ""}>
           Completed

--- a/src/components/Withdrawal/RequestWithdrawalV0.tsx
+++ b/src/components/Withdrawal/RequestWithdrawalV0.tsx
@@ -69,7 +69,10 @@ const RequestWithdrawalV0: React.FC = () => {
     }
 
     e.on("sent", (txHash) => {
-      notification.success({ message: `Withdrawal Tx(${txHash}) has been sent, waiting for it to be committed.` });
+      notification.success({
+        message: `Withdrawal Tx(${txHash}) has been sent,it will take less than 5 minutes before the tx can be tracked and appear in the pending list, please wait...`,
+        duration: 0,
+      });
       setCKBInput("");
       setSudtValue("");
       setLoading(false);

--- a/src/components/Withdrawal/RequestWithdrawalV1.tsx
+++ b/src/components/Withdrawal/RequestWithdrawalV1.tsx
@@ -76,7 +76,10 @@ const RequestWithdrawalV1: React.FC<{ addTxToHistory: (txHistory: BaseL1TxHistor
     }
 
     eventEmitter.on("sent", (txHash) => {
-      notification.success({ message: `Withdrawal Tx(${txHash}) has been sent, waiting for it to be committed.` });
+      notification.success({
+        message: `Withdrawal Tx(${txHash}) has been sent,it will take less than 5 minutes before the tx can be tracked and appear in the pending list, please wait...`,
+        duration: 0,
+      });
       setCKBInput("");
       setSudtValue("");
       setLoading(false);


### PR DESCRIPTION
motivation: Users don't know where their assets are when they make a withdrawal request so they could get anxious about losing their funds.

This pr has:

- added a more detailed prompt when a user makes a withdrawal request
- added tooltip in the pending list

---

<img width="400" alt="image" src="https://user-images.githubusercontent.com/3870972/177499467-2c50830e-0c83-46b9-9152-b89ba8f0a3ff.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/3870972/177499366-3b25dbc5-ce51-402f-923d-1ba2ebe1ab59.png">
