### PR TITLE
docs: fixing syntax

### DIFF
--- a/docs/advanced-settings.md
+++ b/docs/advanced-settings.md
@@ -11,7 +11,7 @@ How:
 1. Go to Godwoken Bridge: https://light-godwoken-git-advanced-settings-cryptape.vercel.app/#/v1
 2. Open developer tools in browser and navigate to `Application`, find `local storage` in left panel: 
 <img width="1914" alt="image" src="https://user-images.githubusercontent.com/3870972/172973026-0b0a4900-5b73-4483-8b95-b516a25b4f6c.png">
-3. Change `MIN_CANCEL_DEPOSIT_TIME` to an acceptable time (I change it to `1`) to wait for the deposit to expire. The time unit is in seconds. Then you can **refresh** the page and fire a deposit. After a short time, the deposit should be canceled.
+3. Change `MIN_CANCEL_DEPOSIT_TIME` to an acceptable time (I change it to `1`) to wait for the deposit to expire. The time unit is in seconds. Then you can **refresh** the page and fire a deposit. After a short time, the deposit will become cancelable. 
 <img width="456" alt="image" src="https://user-images.githubusercontent.com/3870972/172973643-de549245-0f89-4ce9-a03c-035c88a53b88.png">
 
 

--- a/docs/advanced-settings.md
+++ b/docs/advanced-settings.md
@@ -8,10 +8,10 @@ Why:
 
 How: 
 
-1. go to Godwoken Bridge: https://light-godwoken-git-advanced-settings-cryptape.vercel.app/#/v1
-2. open developer tools in browser and navigate to `Application`, find `local storage` in left panel: 
+1. Go to Godwoken Bridge: https://light-godwoken-git-advanced-settings-cryptape.vercel.app/#/v1
+2. Open developer tools in browser and navigate to `Application`, find `local storage` in left panel: 
 <img width="1914" alt="image" src="https://user-images.githubusercontent.com/3870972/172973026-0b0a4900-5b73-4483-8b95-b516a25b4f6c.png">
-3. change `MIN_CANCEL_DEPOSIT_TIME` to an acceptable time(I change it to `1`) to wait for the deposit to expire. The time unit is seconds. Then you can **refresh** the page and fire a deposit. After a short time, the deposit should be cancelable.
+3. Change `MIN_CANCEL_DEPOSIT_TIME` to an acceptable time (I change it to `1`) to wait for the deposit to expire. The time unit is in seconds. Then you can **refresh** the page and fire a deposit. After a short time, the deposit should be canceled.
 <img width="456" alt="image" src="https://user-images.githubusercontent.com/3870972/172973643-de549245-0f89-4ce9-a03c-035c88a53b88.png">
 
 


### PR DESCRIPTION
line 11, 12, 14: Capitalizing list 
line 14: The time unit is seconds. -> The time unit is in seconds. - cancelable -> canceled
line 20: Why other deposit histories are gone after I changed this setting? -> Why is the deposit history gone after I change this setting?
line 21: for the current account -> to the current account