### PR TITLE
feat: extract free capacity from SUDT cells that have more than 144 ckb

### DIFF
--- a/src/light-godwoken/__tests__/lightGodwoken.spec.ts
+++ b/src/light-godwoken/__tests__/lightGodwoken.spec.ts
@@ -1,0 +1,74 @@
+import LightGodwokenV1 from "../LightGodwokenV1";
+import DefaultLightGodwokenProvider from "../lightGodwokenProvider";
+import { generateCellInput, randomHexString } from "./utils";
+import { testConfig } from "./lightGodwokenConfig";
+import { BI, Cell, Script } from "@ckb-lumos/lumos";
+
+let lightGodwokenV1: LightGodwokenV1;
+let lightGodwokenProviderV1: DefaultLightGodwokenProvider;
+beforeEach(() => {
+  const ethAddress = "0x0C1EfCCa2Bcb65A532274f3eF24c044EF4ab6D73";
+  const dummyEthereum = {
+    on: () => {},
+  };
+  lightGodwokenProviderV1 = new DefaultLightGodwokenProvider(ethAddress, dummyEthereum, "v1", testConfig);
+  lightGodwokenV1 = new LightGodwokenV1(lightGodwokenProviderV1);
+});
+
+describe("test light godwoken generateDepositOutputCell", () => {
+  it("should deposit 400 CKB", async () => {
+    const collectedCells: Cell[] = [generateCellInput(400)];
+    const outputCells = await lightGodwokenV1.generateDepositOutputCell(collectedCells, [], {
+      capacity: BI.from(400_00000000).toHexString(),
+    });
+    expect(outputCells.length).toEqual(1);
+    expect(outputCells[0].cell_output.capacity).toEqual(BI.from(400_00000000).toHexString());
+  });
+  it("should deposit 400 CKB, 300 pure CKB and 100 free CKB", async () => {
+    const typeScript: Script = {
+      code_hash: lightGodwokenV1.getConfig().layer1Config.SCRIPTS.sudt.code_hash,
+      hash_type: lightGodwokenV1.getConfig().layer1Config.SCRIPTS.sudt.hash_type,
+      args: randomHexString(32),
+    };
+    const collectedCells: Cell[] = [generateCellInput(300)];
+    const freeCKBCells: Cell[] = [generateCellInput(144 + 100, typeScript, 1)];
+    const outputCells = await lightGodwokenV1.generateDepositOutputCell(collectedCells, freeCKBCells, {
+      capacity: BI.from(400_00000000).toHexString(),
+    });
+    expect(outputCells.length).toEqual(2);
+    expect(outputCells[0].cell_output.capacity).toEqual(BI.from(144_00000000).toHexString());
+    expect(outputCells[0].cell_output.type).toEqual(typeScript);
+    expect(outputCells[1].cell_output.capacity).toEqual(BI.from(400_00000000).toHexString());
+  });
+  it("should deposit 400 CKB, 250 pure CKB and 100 from free CKB and 50 from sudt cell", async () => {
+    const freeTypeScript: Script = {
+      code_hash: lightGodwokenV1.getConfig().layer1Config.SCRIPTS.sudt.code_hash,
+      hash_type: lightGodwokenV1.getConfig().layer1Config.SCRIPTS.sudt.hash_type,
+      args: randomHexString(32),
+    };
+    const depositSudtTypeScript: Script = {
+      code_hash: lightGodwokenV1.getConfig().layer1Config.SCRIPTS.sudt.code_hash,
+      hash_type: lightGodwokenV1.getConfig().layer1Config.SCRIPTS.sudt.hash_type,
+      args: randomHexString(32),
+    };
+    const pureCKBCells: Cell[] = [generateCellInput(250)];
+    const freeCKBCells: Cell[] = [generateCellInput(144 + 100, freeTypeScript, 1)];
+    const sudtCells: Cell[] = [generateCellInput(144 + 50, depositSudtTypeScript, 2)];
+    const outputCells = await lightGodwokenV1.generateDepositOutputCell([...pureCKBCells, ...sudtCells], freeCKBCells, {
+      capacity: BI.from(400_00000000).toHexString(),
+      amount: BI.from(2).mul(1000000000000000000).toHexString(),
+      sudtType: depositSudtTypeScript,
+    });
+    expect(outputCells.length).toEqual(3);
+    // output 0 is free ckb provider cell after taken free ckb away
+    expect(outputCells[0].cell_output.capacity).toEqual(BI.from(144_00000000).toHexString());
+    expect(outputCells[0].cell_output.type).toEqual(freeTypeScript);
+    // output 1 is deposit cell
+    expect(outputCells[1].cell_output.capacity).toEqual(BI.from(400_00000000).toHexString());
+    expect(outputCells[1].cell_output.type).toEqual(depositSudtTypeScript);
+    // output 2 is exchangecell
+    expect(outputCells[2].cell_output.capacity).toEqual(BI.from(144_00000000).toHexString());
+    expect(outputCells[2].cell_output.type).toEqual(undefined);
+    expect(outputCells[2].cell_output.lock).toEqual(lightGodwokenV1.provider.getLayer1Lock());
+  });
+});

--- a/src/light-godwoken/lightGodwoken.ts
+++ b/src/light-godwoken/lightGodwoken.ts
@@ -312,7 +312,7 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
     eventEmiter?: EventEmitter,
   ): Promise<helpers.TransactionSkeletonType> {
     let neededCapacity = BI.from(payload.capacity);
-    if (!BI.from(payload.capacity).eq(await this.provider.getL1CkbBalance())) {
+    if (!BI.from(payload.capacity).eq(await this.getL1CkbBalance())) {
       // if user don't deposit all ckb, we will need to collect 64 more ckb for exchange
       neededCapacity = neededCapacity.add(BI.from(6400000000));
     }
@@ -776,14 +776,7 @@ export default abstract class DefaultLightGodwoken implements LightGodwokenBase 
   }
 
   async getL1CkbBalance(payload?: GetL1CkbBalancePayload): Promise<HexNumber> {
-    const collector = this.provider.ckbIndexer.collector({ lock: helpers.parseAddress(this.provider.l1Address) });
-    let collectedSum = BI.from(0);
-    for await (const cell of collector.collect()) {
-      if (!cell.cell_output.type && (!cell.data || cell.data === "0x" || cell.data === "0x0")) {
-        collectedSum = collectedSum.add(cell.cell_output.capacity);
-      }
-    }
-    return "0x" + collectedSum.toString(16);
+    return (await this.provider.getL1CkbBalance(payload)).toHexString();
   }
 
   async getSudtBalances(payload: GetSudtBalances): Promise<GetSudtBalancesResult> {

--- a/src/light-godwoken/lightGodwokenProvider.ts
+++ b/src/light-godwoken/lightGodwokenProvider.ts
@@ -19,7 +19,7 @@ import { PolyjuiceHttpProvider } from "@polyjuice-provider/web3";
 import { SUDT_ERC20_PROXY_ABI } from "./constants/sudtErc20ProxyAbi";
 import { AbiItems } from "@polyjuice-provider/base";
 import Web3 from "web3";
-import { LightGodwokenProvider } from "./lightGodwokenType";
+import { GetL1CkbBalancePayload, LightGodwokenProvider } from "./lightGodwokenType";
 import { debug } from "./debug";
 import { claimUSDC } from "./sudtFaucet";
 import { GodwokenVersion, LightGodwokenConfig, LightGodwokenConfigMap } from "./constants/configTypes";
@@ -88,9 +88,10 @@ export default class DefaultLightGodwokenProvider implements LightGodwokenProvid
     return this.l1Address;
   }
 
-  async getL1CkbBalance(): Promise<BI> {
+  async getL1CkbBalance(payload?: GetL1CkbBalancePayload): Promise<BI> {
+    const queryAddress = !!payload && !!payload.l1Address ? payload.l1Address : this.l1Address;
     const ckbCollector = this.ckbIndexer.collector({
-      lock: helpers.parseAddress(this.l1Address),
+      lock: helpers.parseAddress(queryAddress),
       type: "empty",
       outputDataLenRange: ["0x0", "0x1"],
     });

--- a/src/light-godwoken/lightGodwokenProvider.ts
+++ b/src/light-godwoken/lightGodwokenProvider.ts
@@ -19,7 +19,7 @@ import { PolyjuiceHttpProvider } from "@polyjuice-provider/web3";
 import { SUDT_ERC20_PROXY_ABI } from "./constants/sudtErc20ProxyAbi";
 import { AbiItems } from "@polyjuice-provider/base";
 import Web3 from "web3";
-import { GetL1CkbBalancePayload, LightGodwokenProvider } from "./lightGodwokenType";
+import { GetL1CkbBalancePayload, LightGodwokenProvider, SUDT_CELL_CAPACITY } from "./lightGodwokenType";
 import { debug } from "./debug";
 import { claimUSDC } from "./sudtFaucet";
 import { GodwokenVersion, LightGodwokenConfig, LightGodwokenConfigMap } from "./constants/configTypes";
@@ -90,14 +90,25 @@ export default class DefaultLightGodwokenProvider implements LightGodwokenProvid
 
   async getL1CkbBalance(payload?: GetL1CkbBalancePayload): Promise<BI> {
     const queryAddress = !!payload && !!payload.l1Address ? payload.l1Address : this.l1Address;
-    const ckbCollector = this.ckbIndexer.collector({
+    let ckbBalance = BI.from(0);
+    const pureCkbCollector = this.ckbIndexer.collector({
       lock: helpers.parseAddress(queryAddress),
       type: "empty",
       outputDataLenRange: ["0x0", "0x1"],
     });
-    let ckbBalance = BI.from(0);
-    for await (const cell of ckbCollector.collect()) {
+    for await (const cell of pureCkbCollector.collect()) {
       ckbBalance = ckbBalance.add(cell.cell_output.capacity);
+    }
+    const freeCkbCollector = this.ckbIndexer.collector({
+      lock: helpers.parseAddress(queryAddress),
+      type: {
+        code_hash: this.getConfig().layer1Config.SCRIPTS.sudt.code_hash,
+        hash_type: this.getConfig().layer1Config.SCRIPTS.sudt.hash_type,
+        args: "0x",
+      },
+    });
+    for await (const cell of freeCkbCollector.collect()) {
+      ckbBalance = ckbBalance.add(cell.cell_output.capacity).sub(SUDT_CELL_CAPACITY);
     }
     return ckbBalance;
   }

--- a/src/light-godwoken/lightGodwokenType.ts
+++ b/src/light-godwoken/lightGodwokenType.ts
@@ -130,6 +130,8 @@ type Promisable<T> = Promise<T> | T;
 
 export const CKB_SUDT_ID = 1;
 
+export const SUDT_CELL_CAPACITY = 144_00000000;
+
 export interface LightGodwokenProvider {
   claimUSDC(): Promise<HexString>;
 


### PR DESCRIPTION
motivation: when a user withdraws some SUDT from layer 2, let's say 400 CKB and 1 DAI, the cell received on layer 1 will be just one cell containing these assets. So that 144 CKB in this cell is occupied capacity, and the left 256 CKB should be free capacity and taken into count when getting the user's layer 1 CKB balance.

This PR has: 
 - take free capacity into count when getting the user's layer 1 CKB balance
 - take free capacity into count when the user tries to deposit CKB
 - add test case for free capacity when the user deposits