### PR TITLE
refactor: rename native asset info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# editors
+/.idea
+
 # dependencies
 /node_modules
 /.pnp

--- a/src/light-godwoken/LightGodwokenV0.ts
+++ b/src/light-godwoken/LightGodwokenV0.ts
@@ -87,11 +87,11 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
 
   getNativeAsset(): UniversalToken {
     return {
-      name: "pCKB",
-      symbol: "pCKB",
+      name: "Common Knowledge Base",
+      symbol: "CKB",
       decimals: 8,
       tokenURI: "",
-      uan: "pCKB.gw|gb.ckb",
+      uan: "CKB.ckb",
     };
   }
 

--- a/src/light-godwoken/LightGodwokenV0.ts
+++ b/src/light-godwoken/LightGodwokenV0.ts
@@ -87,11 +87,11 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
 
   getNativeAsset(): UniversalToken {
     return {
-      name: "Common Knowledge Base",
-      symbol: "CKB",
+      name: "pCKB",
+      symbol: "pCKB",
       decimals: 8,
       tokenURI: "",
-      uan: "CKB.ckb",
+      uan: "pCKB.gw|gb.ckb",
     };
   }
 

--- a/src/light-godwoken/LightGodwokenV1.ts
+++ b/src/light-godwoken/LightGodwokenV1.ts
@@ -78,11 +78,11 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
 
   getNativeAsset(): UniversalToken {
     return {
-      name: "Common Knowledge Base",
-      symbol: "CKB",
+      name: "pCKB",
+      symbol: "pCKB",
       decimals: 18,
       tokenURI: "",
-      uan: "CKB.ckb",
+      uan: "pCKB.gw|gb.ckb",
     };
   }
 


### PR DESCRIPTION
Changes in the PR:
- Change native asset's info, from 'CKB' to 'pCKB'
- Only changing V1's info

Remaining issues:
- request `wallet_addEthereumChain` won't work for Users who have added godwoken's chain info to their MetaMask, so the changes to native asset info are transparent to them, is there anything we can do?
- On MetaMask, symbols are all `uppercase`, so 'pCKB' on MetaMask is displayed as 'PCKB', does it bother?