### PR TITLE
fix: conditional estimated time

### DIFF
--- a/src/components/Withdrawal/WithdrawalItemV1.tsx
+++ b/src/components/Withdrawal/WithdrawalItemV1.tsx
@@ -127,10 +127,12 @@ const WithdrawalRequestCard = ({
   const estimatedSecondsLeft = useMemo(() => Math.max(0, estimatedArrivalDate - now), [now, estimatedArrivalDate]);
   const isMature = useMemo(() => remainingBlockNumber === 0, [remainingBlockNumber]);
 
-  const { days: daysLeft, hours: hoursLeft, minutes: minutesLeft, seconds: secondsLeft } = useMemo(
-    () => getTimePeriods(estimatedSecondsLeft / 1000),
-    [estimatedSecondsLeft],
-  );
+  const {
+    days: daysLeft,
+    hours: hoursLeft,
+    minutes: minutesLeft,
+    seconds: secondsLeft,
+  } = useMemo(() => getTimePeriods(estimatedSecondsLeft / 1000), [estimatedSecondsLeft]);
 
   const [CKBAmount] = useMemo(() => {
     if (capacity === "0") {
@@ -167,8 +169,8 @@ const WithdrawalRequestCard = ({
             ) : (
               <div className="time">
                 <MainText title="Estimated time left">
-                  {daysLeft && `${daysLeft} day${daysLeft > 1 && "s"}, `}
-                  {hoursLeft && `${hoursLeft.toString().padStart(2, "0")}:`}
+                  {daysLeft ? `${daysLeft} day${daysLeft > 1 ? "s" : ""}, ` : ""}
+                  {hoursLeft ? `${hoursLeft.toString().padStart(2, "0")}:` : ""}
                   {`${minutesLeft.toString().padStart(2, "0")}:`}
                   {`${secondsLeft.toString().padStart(2, "0")}`}
                 </MainText>
@@ -214,8 +216,8 @@ const WithdrawalRequestCard = ({
           <FixedHeightRow>
             <MainText>Estimated time left:</MainText>
             <MainText>
-              {daysLeft && `${daysLeft} day${daysLeft > 0 && "s"}, `}
-              {hoursLeft && `${hoursLeft.toString().padStart(2, "0")}:`}
+              {daysLeft ? `${daysLeft} day${daysLeft > 1 ? "s" : ""}, ` : ""}
+              {hoursLeft ? `${hoursLeft.toString().padStart(2, "0")}:` : ""}
               {`${minutesLeft.toString().padStart(2, "0")}:`}
               {`${secondsLeft.toString().padStart(2, "0")}`}
             </MainText>


### PR DESCRIPTION
There was a bug in the previous commit about estimated time.

Where:
```tsx
{daysLeft && `${daysLeft} day${daysLeft > 1 && "s"}, `}
```
Since `daysLeft` is a Number typed value, and when `daysLeft = 0`, the code above will output "0".
But our expected output is valid time or empty, the output "0" is not what we wanted.

Changing the condition to the following should fix the bug:
```tsx
{daysLeft ? `${daysLeft} day${daysLeft > 1 ? "s" : ""}, ` : ""}
```